### PR TITLE
Fix missing libgomp.so.1 Error in Docker Container for llama.cpp

### DIFF
--- a/.devops/server-cuda.Dockerfile
+++ b/.devops/server-cuda.Dockerfile
@@ -30,7 +30,7 @@ RUN make -j$(nproc)
 FROM ${BASE_CUDA_RUN_CONTAINER} as runtime
 
 RUN apt-get update && \
-    apt-get install -y libcurl4-openssl-dev
+    apt-get install -y libcurl4-openssl-dev libgomp1
 
 COPY --from=build /app/server /server
 


### PR DESCRIPTION
This pull request resolves the issue of the missing `libgomp.so.1` library when running the `llama.cpp` Docker container. The error was encountered as follows:

```
/server: error while loading shared libraries: libgomp.so.1: cannot open shared object file: No such file or directory
```

The fix involves adding the installation of `libgomp1` to the Dockerfile to ensure that the necessary library is present in the container.

#### Changes Made:
- Updated the Dockerfile to include `libgomp1` in the list of packages installed during the build process.

#### Updated Dockerfile Segment:
```Dockerfile
RUN apt-get update && \
    apt-get install -y libcurl4-openssl-dev libgomp1
```

With this update, users should be able to run the llama.cpp container without encountering the `libgomp.so.1` error.